### PR TITLE
Takes advantage of TypeScript baseUrl property

### DIFF
--- a/src/array/contains.ts
+++ b/src/array/contains.ts
@@ -2,10 +2,10 @@
  *
  */
 
-import pipeValue from '../core/pipe-value';
-import equals from '../core/equals';
+import pipeValue from 'core/pipe-value';
+import equals from 'core/equals';
 import length from './length';
-import gte from '../number/gte';
+import gte from 'number/gte';
 import filter from './filter';
 
 type T = <A extends unknown>(value: A) => (array: A[]) => boolean;

--- a/src/array/map-between.ts
+++ b/src/array/map-between.ts
@@ -2,7 +2,7 @@
  *
  */
 
-import pipeValue from '../core/pipe-value';
+import pipeValue from 'core/pipe-value';
 import front from './front';
 import map from './map';
 

--- a/src/aws/arn-parts.ts
+++ b/src/aws/arn-parts.ts
@@ -3,7 +3,7 @@
  */
 
 import Region from './type/region';
-import explode from '../regex/explode';
+import explode from 'regex/explode';
 
 interface ArnParts {
     service: string;

--- a/src/code-edit/indent-line.ts
+++ b/src/code-edit/indent-line.ts
@@ -4,7 +4,7 @@
 
 import Indentation from './type/indentation';
 import indentationString from './indentation-string';
-import explode from '../regex/explode';
+import explode from 'regex/explode';
 
 type T = (indentation: Indentation) => (line: string) => string;
 

--- a/src/code-edit/indent.ts
+++ b/src/code-edit/indent.ts
@@ -8,7 +8,7 @@ import isMultiLineSelection from './is-multi-line-selection';
 import linesInSelection from './lines-in-selection';
 import indentLine from './indent-line';
 import indentationString from './indentation-string';
-import contains from '../array/contains';
+import contains from 'array/contains';
 
 type T = (indentation: Indentation) => (code: Code) => Code;
 

--- a/src/code-edit/is-multi-line-selection.ts
+++ b/src/code-edit/is-multi-line-selection.ts
@@ -3,7 +3,7 @@
  */
 
 import Code from './type/code';
-import contains from '../string/contains';
+import contains from 'string/contains';
 
 type T = (code: Code) => boolean;
 

--- a/src/code-edit/line-number-digits.spec.ts
+++ b/src/code-edit/line-number-digits.spec.ts
@@ -1,5 +1,5 @@
 import lineNumberDigits from './line-number-digits';
-import range from '../number/range';
+import range from 'number/range';
 
 describe('code-edit/lineNumberDigits', () => {
     it('returns 1 for empty source code', () => {

--- a/src/code-edit/line-number-digits.ts
+++ b/src/code-edit/line-number-digits.ts
@@ -2,8 +2,8 @@
  *
  */
 
-import pipe from '../core/pipe';
-import split from '../string/split';
+import pipe from 'core/pipe';
+import split from 'string/split';
 
 type T = (source: string) => number;
 

--- a/src/code-edit/lines-in-selection.ts
+++ b/src/code-edit/lines-in-selection.ts
@@ -3,7 +3,7 @@
  */
 
 import Code from './type/code';
-import range from '../number/range';
+import range from 'number/range';
 
 type T = (code: Code) => number[];
 

--- a/src/code-edit/outdent.ts
+++ b/src/code-edit/outdent.ts
@@ -6,7 +6,7 @@ import Code from './type/code';
 import Indentation from './type/indentation';
 import linesInSelection from './lines-in-selection';
 import outdentLine from './outdent-line';
-import contains from '../array/contains';
+import contains from 'array/contains';
 
 type T = (indentation: Indentation) => (code: Code) => Code;
 

--- a/src/layout/along-axis.ts
+++ b/src/layout/along-axis.ts
@@ -2,15 +2,15 @@
  *
  */
 
-import Dimensions from '../geometry/type/dimensions';
-import Coordinates from '../geometry/type/coordinates';
+import Dimensions from 'geometry/type/dimensions';
+import Coordinates from 'geometry/type/coordinates';
 import OrientationString from './type/orientation-string';
 import orientationFromString from './orientation-from-string';
-import pipeValue from '../core/pipe-value';
-import map from '../array/map';
-import reduce from '../array/reduce';
-import max from '../number/max';
-import add from '../math/add';
+import pipeValue from 'core/pipe-value';
+import map from 'array/map';
+import reduce from 'array/reduce';
+import max from 'number/max';
+import add from 'math/add';
 import mainDimension from './main-dimension';
 import crossDimension from './cross-dimension';
 

--- a/src/layout/cross-dimension.ts
+++ b/src/layout/cross-dimension.ts
@@ -3,7 +3,7 @@
  */
 
 import Orientation from './type/orientation';
-import Dimensions from '../geometry/type/dimensions';
+import Dimensions from 'geometry/type/dimensions';
 
 type T = (layout: Orientation['main']) => (box: Dimensions) => number;
 

--- a/src/layout/main-dimension.ts
+++ b/src/layout/main-dimension.ts
@@ -3,7 +3,7 @@
  */
 
 import Orientation from './type/orientation';
-import Dimensions from '../geometry/type/dimensions';
+import Dimensions from 'geometry/type/dimensions';
 
 type T = (layout: Orientation['main']) => (box: Dimensions) => number;
 

--- a/src/layout/orientation-from-string.ts
+++ b/src/layout/orientation-from-string.ts
@@ -4,8 +4,8 @@
 
 import Orientation from './type/orientation';
 import OrientationString from './type/orientation-string';
-import pipe from '../core/pipe';
-import split from '../string/split';
+import pipe from 'core/pipe';
+import split from 'string/split';
 import crossAxisPosition from './cross-axis-position';
 
 type T = (orientationString: OrientationString) => Orientation;

--- a/src/math/random.ts
+++ b/src/math/random.ts
@@ -2,7 +2,7 @@
  *
  */
 
-import pipe from '../core/pipe';
+import pipe from 'core/pipe';
 import interpolate from './interpolate';
 
 type T = (minimum: number) => (maximum: number) => number;

--- a/src/object/is-object.ts
+++ b/src/object/is-object.ts
@@ -2,7 +2,7 @@
  *
  */
 
-import isArray from '../array/is-array';
+import isArray from 'array/is-array';
 
 type T = (value: unknown) => boolean;
 

--- a/src/pan-zoom/center-screen-transformation.ts
+++ b/src/pan-zoom/center-screen-transformation.ts
@@ -2,9 +2,9 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import pipeValue from '../core/pipe-value';
-import divide from '../vector/divide';
+import Vector from 'vector/type/vector';
+import pipeValue from 'core/pipe-value';
+import divide from 'vector/divide';
 
 import zoomTransformation from './zoom-transformation';
 

--- a/src/pan-zoom/center-world-transformation.ts
+++ b/src/pan-zoom/center-world-transformation.ts
@@ -2,8 +2,8 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import divide from '../vector/divide';
+import Vector from 'vector/type/vector';
+import divide from 'vector/divide';
 
 type T = (worldSize: Vector) => Vector;
 

--- a/src/pan-zoom/transformation.ts
+++ b/src/pan-zoom/transformation.ts
@@ -2,9 +2,9 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import pipeValue from '../core/pipe-value';
-import add from '../vector/add';
+import Vector from 'vector/type/vector';
+import pipeValue from 'core/pipe-value';
+import add from 'vector/add';
 import centerScreenTransformation from './center-screen-transformation';
 import centerWorldTransformation from './center-world-transformation';
 

--- a/src/pan-zoom/world-coordinates.ts
+++ b/src/pan-zoom/world-coordinates.ts
@@ -2,8 +2,8 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import add from '../vector/add';
+import Vector from 'vector/type/vector';
+import add from 'vector/add';
 
 type T = (transformation: Vector) => (screenCoordinates: Vector) => Vector;
 

--- a/src/pan-zoom/zoom-offset.ts
+++ b/src/pan-zoom/zoom-offset.ts
@@ -2,11 +2,11 @@
  *
  */
 
-import Vector from '../vector/type/vector';
+import Vector from 'vector/type/vector';
 import worldCoordinates from './world-coordinates';
 import transformation from './transformation';
-import divide from '../vector/divide';
-import subtract from '../vector/subtract';
+import divide from 'vector/divide';
+import subtract from 'vector/subtract';
 
 type T = (screenSize: Vector) => (worldSize: Vector) => (pan: Vector) => (previousZoom: number) => (newZoom: number) => (origin: Vector) => Vector;
 

--- a/src/pan-zoom/zoom-transformation.ts
+++ b/src/pan-zoom/zoom-transformation.ts
@@ -2,8 +2,8 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import divide from '../vector/divide';
+import Vector from 'vector/type/vector';
+import divide from 'vector/divide';
 
 type T = (screenSize: Vector) => (zoom: number) => Vector;
 

--- a/src/regex/flags-to-string.ts
+++ b/src/regex/flags-to-string.ts
@@ -3,7 +3,7 @@
  */
 
 import Flags from './type/flags';
-import pipe from '../core/pipe';
+import pipe from 'core/pipe';
 
 type T = (flags: Flags) => string;
 

--- a/src/regex/matches.ts
+++ b/src/regex/matches.ts
@@ -2,10 +2,10 @@
  *
  */
 
-import pipeValue from '../core/pipe-value';
+import pipeValue from 'core/pipe-value';
 import match from './match';
-import length from '../array/length';
-import gt from '../number/gt';
+import length from 'array/length';
+import gt from 'number/gt';
 
 type T = (regex: RegExp | string) => (value: string) => boolean;
 

--- a/src/regex/set-global.ts
+++ b/src/regex/set-global.ts
@@ -2,7 +2,7 @@
  *
  */
 
-import pipeValue from '../core/pipe-value';
+import pipeValue from 'core/pipe-value';
 import flags from './flags';
 import toString from './flags-to-string';
 

--- a/src/stack/next.ts
+++ b/src/stack/next.ts
@@ -3,7 +3,7 @@
  */
 
 import Stack from './type/stack';
-import last from '../array/last';
+import last from 'array/last';
 
 type T = <A extends unknown>(stack: Stack<A>) => A | undefined;
 

--- a/src/string/fuzzy-search.ts
+++ b/src/string/fuzzy-search.ts
@@ -2,10 +2,10 @@
  *
  */
 
-import pipeValue from '../core/pipe-value';
+import pipeValue from 'core/pipe-value';
 import split from './split';
-import join from '../array/join';
-import matches from '../regex/matches';
+import join from 'array/join';
+import matches from 'regex/matches';
 
 type T = (haystack: string) => (needle: string) => boolean;
 

--- a/src/string/split-before.ts
+++ b/src/string/split-before.ts
@@ -3,9 +3,9 @@
  */
 
 import Parts from './type/parts';
-import setGlobal from '../regex/set-global';
+import setGlobal from 'regex/set-global';
 import split from './split';
-import mapMultiple from '../array/map-multiple';
+import mapMultiple from 'array/map-multiple';
 import concat from './concat';
 
 type T = (delimiter: string | RegExp) => (value: string) => Parts;

--- a/src/string/to-sentence-case.ts
+++ b/src/string/to-sentence-case.ts
@@ -3,10 +3,10 @@
  */
 
 import Parts from './type/parts';
-import pipe from '../core/pipe';
-import map from '../array/map';
+import pipe from 'core/pipe';
+import map from 'array/map';
 import upperCaseFirst from './upper-case-first';
-import join from '../array/join';
+import join from 'array/join';
 
 type T = (parts: Parts) => string;
 

--- a/src/string/to-title-case.ts
+++ b/src/string/to-title-case.ts
@@ -3,8 +3,8 @@
  */
 
 import Parts from './type/parts';
-import pipe from '../core/pipe';
-import join from '../array/join';
+import pipe from 'core/pipe';
+import join from 'array/join';
 import upperCaseFirst from './upper-case-first';
 
 type T = (parts: Parts) => string;

--- a/src/svg/view-box.ts
+++ b/src/svg/view-box.ts
@@ -2,13 +2,13 @@
  *
  */
 
-import Vector from '../vector/type/vector';
-import pipeValue from '../core/pipe-value';
-import worldCoordinates from '../pan-zoom/world-coordinates';
-import transformation from '../pan-zoom/transformation';
-import map from '../array/map';
-import join from '../array/join';
-import append from '../string/append';
+import Vector from 'vector/type/vector';
+import pipeValue from 'core/pipe-value';
+import worldCoordinates from 'pan-zoom/world-coordinates';
+import transformation from 'pan-zoom/transformation';
+import map from 'array/map';
+import join from 'array/join';
+import append from 'string/append';
 
 type T = (screenSize: Vector) => (worldSize: Vector) => (pan: Vector) => (zoom: number) => string;
 

--- a/src/url/parts.ts
+++ b/src/url/parts.ts
@@ -3,9 +3,9 @@
  */
 
 import Parts from './type/parts';
-// import pipe from '../core/pipe';
-// import explode from '../regex/explode';
-// import parseInt from '../number/parse-int';
+// import pipe from 'core/pipe';
+// import explode from 'regex/explode';
+// import parseInt from 'number/parse-int';
 
 type T = (url: string) => Parts;
 

--- a/src/vector/add.ts
+++ b/src/vector/add.ts
@@ -3,8 +3,8 @@
  */
 
 import Vector from './type/vector';
-import mapMultiple from '../array/map-multiple';
-import add from '../math/add';
+import mapMultiple from 'array/map-multiple';
+import add from 'math/add';
 
 type T = (first: Vector) => (second: Vector) => Vector;
 

--- a/src/vector/divide.ts
+++ b/src/vector/divide.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import divide from '../math/divide';
+import divide from 'math/divide';
 
 type T = (scaleFactor: number) => (value: Vector) => Vector;
 

--- a/src/vector/from-coordinates.ts
+++ b/src/vector/from-coordinates.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import Coordinates from '../geometry/type/coordinates';
+import Coordinates from 'geometry/type/coordinates';
 
 type T = (value: Coordinates) => Vector;
 

--- a/src/vector/from-dimensions.ts
+++ b/src/vector/from-dimensions.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import Dimensions from '../geometry/type/dimensions';
+import Dimensions from 'geometry/type/dimensions';
 
 type T = (value: Dimensions) => Vector;
 

--- a/src/vector/multiply.ts
+++ b/src/vector/multiply.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import multiply from '../math/multiply';
+import multiply from 'math/multiply';
 
 type T = (scaleFactor: number) => (value: Vector) => Vector;
 

--- a/src/vector/subtract.ts
+++ b/src/vector/subtract.ts
@@ -3,8 +3,8 @@
  */
 
 import Vector from './type/vector';
-import mapMultiple from '../array/map-multiple';
-import subtract from '../math/subtract';
+import mapMultiple from 'array/map-multiple';
+import subtract from 'math/subtract';
 
 type T = (first: Vector) => (second: Vector) => Vector;
 

--- a/src/vector/to-coordinates.ts
+++ b/src/vector/to-coordinates.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import Coordinates from '../geometry/type/coordinates';
+import Coordinates from 'geometry/type/coordinates';
 
 type T = (value: Vector) => Coordinates;
 

--- a/src/vector/to-dimensions.ts
+++ b/src/vector/to-dimensions.ts
@@ -3,7 +3,7 @@
  */
 
 import Vector from './type/vector';
-import Dimensions from '../geometry/type/dimensions';
+import Dimensions from 'geometry/type/dimensions';
 
 type T = (value: Vector) => Dimensions;
 


### PR DESCRIPTION
Relative imports can and should now import using paths starting at the `src` directory. Any module relying on another module should import thusly:

```ts
import example from 'moduleName/example';
```